### PR TITLE
Replacing git url

### DIFF
--- a/getting-started-service-mesh.md
+++ b/getting-started-service-mesh.md
@@ -145,7 +145,7 @@ Click on the **Import Projects...** in **Workspace** menu and enter the followin
 ![codeready-workspace-import]({% image_path codeready-workspace-menu.png %})
 
   * Version Control System: `GIT`
-  * URL: `https://github.com/RedHat-Middleware-Workshops/cloud-native-workshop-v2m3-labs.git`
+  * URL: `{{GIT_URL}}/userXX/cloud-native-workshop-v2m3-labs.git` (**IMPORTANT**: replace userXX with your lab user)
   * Check `Import recursively (for multi-module projects)`
   * Name: `cloud-native-workshop-v2m3-labs`
 


### PR DESCRIPTION
Replacing git url from external GitHub to the internal gogs url within the cluster