### PR TITLE
Fix typo and minor contents improvements in m3

### DIFF
--- a/advanced-service-mesh-dev.adoc
+++ b/advanced-service-mesh-dev.adoc
@@ -1,7 +1,7 @@
 = Lab 3 - Advanced Service Mesh Development
 :experimental:
 
-In this lab, we will learn the advanced usecases of service mesh. The lab showcases features:
+In this lab, we will learn the advanced use cases of service mesh. The lab showcases features:
 
 * Fault Injection
 * Traffic Shifting
@@ -705,7 +705,7 @@ In order to generate a correct token, run next `curl` request in CodeReady Works
 
 [source,sh,role="copypaste"]
 ----
-export TOKEN=$( curl -X POST 'http://sso-{{ USER_ID }}-rhsso.{{ ROUTE_SUBDOMAIN }}/auth/realms/istio/protocol/openid-connect/token' \
+export TOKEN=$( curl -s -X POST 'http://sso-{{ USER_ID }}-rhsso.{{ ROUTE_SUBDOMAIN }}/auth/realms/istio/protocol/openid-connect/token' \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "username=auth{{ USER_ID }}" \
  -d 'password={{ OPENSHIFT_USER_PASSWORD }}' \
@@ -717,7 +717,7 @@ Once you have generated the token, re-run the curl command below with the token 
 
 [source,sh,role="copypaste"]
 ----
-curl -H "Authorization: Bearer $TOKEN" http://istio-ingressgateway-{{ USER_ID }}-istio-system.{{ ROUTE_SUBDOMAIN }}/services/products | jq
+curl -s -H "Authorization: Bearer $TOKEN" http://istio-ingressgateway-{{ USER_ID }}-istio-system.{{ ROUTE_SUBDOMAIN }}/services/products | jq
 ----
 
 You should see the following expected output:

--- a/creating-distributed-services.adoc
+++ b/creating-distributed-services.adoc
@@ -110,14 +110,14 @@ Open a terminal via CodeReady Workspaces and run the following commands to deplo
 
 [source,shell, role="copypaste"]
 ----
-oc apply -n {{ USER_ID}}-bookinfo -f /projects/cloud-native-workshop-v2m3-labs/istio/bookinfo.yaml
+oc apply -n {{ USER_ID}}-bookinfo -f $CHE_PROJECTS_ROOT/cloud-native-workshop-v2m3-labs/istio/bookinfo.yaml
 ----
 
 And then create the _ingress gateway_ for the bookinfo:
 
 [source,shell, role="copypaste"]
 ----
-oc apply -n {{ USER_ID}}-bookinfo -f /projects/cloud-native-workshop-v2m3-labs/istio/bookinfo-gateway.yaml
+oc apply -n {{ USER_ID}}-bookinfo -f $CHE_PROJECTS_ROOT/cloud-native-workshop-v2m3-labs/istio/bookinfo-gateway.yaml
 ----
 
 The above default ingress manages traffic for any incoming host, but we only want it to manage traffic destined to our own ingress, so change the host from `*` to your specific host with this command:
@@ -131,7 +131,7 @@ Finally, add default destination rules (we’ll alter this later to affect routi
 
 [source,shell, role="copypaste"]
 ----
-oc apply -n {{ USER_ID}}-bookinfo -f /projects/cloud-native-workshop-v2m3-labs/istio/destination-rule-all.yaml
+oc apply -n {{ USER_ID}}-bookinfo -f $CHE_PROJECTS_ROOT/cloud-native-workshop-v2m3-labs/istio/destination-rule-all.yaml
 ----
 
 List all available destination rules:
@@ -154,15 +154,15 @@ oc label deployment/reviews-v1 app.openshift.io/runtime=java --overwrite && \
 oc label deployment/reviews-v2 app.openshift.io/runtime=java --overwrite && \
 oc label deployment/reviews-v3 app.openshift.io/runtime=java --overwrite && \
 oc label deployment/ratings-v1 app.openshift.io/runtime=nodejs --overwrite && \
-oc label deployment details-v1 app.kubernetes.io/part-of=bookinfo --overwrite && \
-oc label deployment productpage-v1 app.kubernetes.io/part-of=bookinfo --overwrite && \
-oc label deployment ratings-v1 app.kubernetes.io/part-of=bookinfo --overwrite && \
-oc label deployment reviews-v1 app.kubernetes.io/part-of=bookinfo --overwrite && \
-oc label deployment reviews-v2 app.kubernetes.io/part-of=bookinfo --overwrite && \
-oc label deployment reviews-v3 app.kubernetes.io/part-of=bookinfo --overwrite && \
-oc annotate deployment productpage-v1 app.openshift.io/connects-to=reviews-v1,reviews-v2,reviews-v3,details-v1 && \
-oc annotate deployment reviews-v2 app.openshift.io/connects-to=ratings-v1 && \
-oc annotate deployment reviews-v3 app.openshift.io/connects-to=ratings-v1
+oc label deployment/details-v1 app.kubernetes.io/part-of=bookinfo --overwrite && \
+oc label deployment/productpage-v1 app.kubernetes.io/part-of=bookinfo --overwrite && \
+oc label deployment/ratings-v1 app.kubernetes.io/part-of=bookinfo --overwrite && \
+oc label deployment/reviews-v1 app.kubernetes.io/part-of=bookinfo --overwrite && \
+oc label deployment/reviews-v2 app.kubernetes.io/part-of=bookinfo --overwrite && \
+oc label deployment/reviews-v3 app.kubernetes.io/part-of=bookinfo --overwrite && \
+oc annotate deployment/productpage-v1 app.openshift.io/connects-to=reviews-v1,reviews-v2,reviews-v3,details-v1 && \
+oc annotate deployment/reviews-v2 app.openshift.io/connects-to=ratings-v1 && \
+oc annotate deployment/reviews-v3 app.openshift.io/connects-to=ratings-v1
 ----
 
 Let’s wait for our application to finish deploying. Go to the {{ CONSOLE_URL }}/topology/ns/{{ USER_ID }}-bookinfo[Topology View^] for the `{{USER_ID}}-bookinfo` project. You'll see the app components spinning up:

--- a/service-visualizing-monitoring.adoc
+++ b/service-visualizing-monitoring.adoc
@@ -1,7 +1,7 @@
 = Lab 2 - Service Visualization and Monitoring
 :experimental:
 
-In this lab you will visualize your service mesh using *Kiali*, *Prometheus*, *Grafana* and you will lean how to configure basic *Istio funtionalities* such as *VirtualService* and *A/B Testing*.
+In this lab you will visualize your service mesh using *Kiali*, *Prometheus*, *Grafana* and you will lean how to configure basic *Istio functionalities* such as *VirtualService* and *A/B Testing*.
 
 === 1. Generating application load
 
@@ -99,7 +99,7 @@ You should see the _OpenShift Login_ screen. Enter the username and password as 
 * Username: `{{ USER_ID }}`
 * Password: `{{ OPENSHIFT_USER_PASSWORD }}`
 
-You will land on the Jaeger query page:
+If you have Requested permissions to authorize access Jaeger, click on Allow selected permissions. You will land on the Jaeger query page:
 
 image::kiali-tracing-jaeger.png[kiali, 700]
 


### PR DESCRIPTION
A brief description of the changes:

> deployment/details-v1

I just removed the white space and used the slash instead because "convention". As the rest of commands have it, having some of them using a different "style" could be "hard to read" or lead to misunderstandings.

> /projects/

I guess it is not a problem as the root is unlikely to change, but It's  just following a convention and I think is a best practice also. In the other modules and even in this one, you're using the env varible instead of the harcoded value.

> curl -H

I used the flag `-s, --silent` wich means: Silent or quiet mode. Don't show progress meter or error messages.
Is just to make the `curl` output more easy to read by removing the stats of your request.

> **NOTE:** There is a [PR](https://github.com/RedHat-Middleware-Workshops/cloud-native-workshop-v2m3-guides/pull/24) for the `ocp-4.5` branch already merged.